### PR TITLE
fix: use specific exceptions and idiomatic None checks

### DIFF
--- a/AgentGym-RL/scripts/model_merger.py
+++ b/AgentGym-RL/scripts/model_merger.py
@@ -99,7 +99,7 @@ if __name__ == '__main__':
         for model_state_dict in model_state_dict_lst:
             try:
                 tensor = model_state_dict.pop(key)
-            except:
+            except KeyError:
                 print("-"*30)
                 print(model_state_dict)
             if isinstance(tensor, DTensor):

--- a/AgentGym-RL/scripts/multiple_model_merger.py
+++ b/AgentGym-RL/scripts/multiple_model_merger.py
@@ -103,7 +103,7 @@ if __name__ == '__main__':
         for model_state_dict in model_state_dict_lst:
             try:
                 tensor = model_state_dict.pop(key)
-            except:
+            except KeyError:
                 print("-"*30)
                 print(model_state_dict)
             if isinstance(tensor, DTensor):

--- a/AgentGym-RL/verl/protocol.py
+++ b/AgentGym-RL/verl/protocol.py
@@ -34,7 +34,7 @@ __all__ = ['DataProto', 'union_tensor_dict']
 
 try:
     tensordict.set_lazy_legacy(False).set()
-except:
+except (AttributeError, ImportError):
     pass
 
 

--- a/AgentGym-RL/verl/single_controller/ray/base.py
+++ b/AgentGym-RL/verl/single_controller/ray/base.py
@@ -426,7 +426,7 @@ def create_colocated_worker_cls(class_dict: dict[str, RayClassWithInitArgs]):
     init_args_dict = {}
     worker_cls = None
     for key, cls in class_dict.items():
-        if worker_cls == None:
+        if worker_cls is None:
             worker_cls = cls.cls.__ray_actor_class__.__base__
         else:
             assert worker_cls == cls.cls.__ray_actor_class__.__base__, \

--- a/AgentGym-RL/verl/third_party/vllm/vllm_v_0_3_1/worker.py
+++ b/AgentGym-RL/verl/third_party/vllm/vllm_v_0_3_1/worker.py
@@ -248,7 +248,7 @@ class Worker:
         load_weights(actor_weights, self.model_runner.model)
 
     def offload_model_weights(self) -> None:
-        if self.cpu_model == None:
+        if self.cpu_model is None:
             self.cpu_model = {}
             for name, params in self.model_runner.model.named_parameters():
                 self.cpu_model[name] = torch.empty_like(params, device='cpu')

--- a/AgentGym-RL/verl/third_party/vllm/vllm_v_0_4_2/worker.py
+++ b/AgentGym-RL/verl/third_party/vllm/vllm_v_0_4_2/worker.py
@@ -244,7 +244,7 @@ class Worker(Worker):
             load_dtensor_weights(actor_weights, self.model_runner.model)
 
     def offload_model_weights(self) -> None:
-        if self.cpu_model == None:
+        if self.cpu_model is None:
             self.cpu_model = {}
             for name, params in self.model_runner.model.named_parameters():
                 self.cpu_model[name] = torch.empty_like(params, device='cpu')

--- a/AgentGym-RL/verl/third_party/vllm/vllm_v_0_5_4/worker.py
+++ b/AgentGym-RL/verl/third_party/vllm/vllm_v_0_5_4/worker.py
@@ -273,7 +273,7 @@ class Worker(Worker):
             load_dtensor_weights(actor_weights, self.model_runner.model)
 
     def offload_model_weights(self) -> None:
-        if self.cpu_model == None:
+        if self.cpu_model is None:
             self.cpu_model = {}
             for name, params in self.model_runner.model.named_parameters():
                 self.cpu_model[name] = torch.empty_like(params, device='cpu')

--- a/AgentGym-RL/verl/third_party/vllm/vllm_v_0_6_3/worker.py
+++ b/AgentGym-RL/verl/third_party/vllm/vllm_v_0_6_3/worker.py
@@ -281,7 +281,7 @@ class Worker(Worker):
             load_dtensor_weights(actor_weights, self.model_runner.model)
 
     def offload_model_weights(self) -> None:
-        if self.cpu_model == None:
+        if self.cpu_model is None:
             self.cpu_model = {}
             for name, params in self.model_runner.model.named_parameters():
                 self.cpu_model[name] = torch.empty_like(params, device="cpu")

--- a/AgentGym-RL/verl/utils/reward_score/prime_math/__init__.py
+++ b/AgentGym-RL/verl/utils/reward_score/prime_math/__init__.py
@@ -73,7 +73,7 @@ def _is_float(num: str) -> bool:
 def _is_int(x: float) -> bool:
     try:
         return abs(x - int(round(x))) <= 1e-7
-    except:
+    except (ValueError, TypeError, OverflowError):
         return False
 
 
@@ -86,7 +86,7 @@ def _str_is_int(x: str) -> bool:
         x = _strip_properly_formatted_commas(x)
         x = float(x)
         return abs(x - int(round(x))) <= 1e-7
-    except:
+    except (ValueError, TypeError, OverflowError):
         return False
 
 

--- a/AgentGym-RL/verl/utils/ulysses.py
+++ b/AgentGym-RL/verl/utils/ulysses.py
@@ -238,7 +238,7 @@ def gather_outpus_and_unpad(x: Tensor,
                             group: Optional[dist.ProcessGroup] = None):
     group = get_ulysses_sequence_parallel_group() if group is None else group
     sp_size = get_ulysses_sequence_parallel_world_size()
-    if group == None:
+    if group is None:
         return x
     x = Gather.apply(group, x, gather_dim, grad_scaler)
     if unpad_dim is not None:


### PR DESCRIPTION
## Changes

### Bare except → specific exceptions (5 sites)
- `model_merger.py`/`multiple_model_merger.py`: `except KeyError`
- `protocol.py`: `except (AttributeError, ImportError)`
- `prime_math/__init__.py`: `except (ValueError, TypeError, OverflowError)` (2 sites)

### `== None` → `is None` (PEP 8 E711, 5 files)
- `ray/base.py`, `vllm_v_0_3_1/worker.py`, `vllm_v_0_4_2/worker.py`, `vllm_v_0_5_4/worker.py`, `vllm_v_0_6_3/worker.py`